### PR TITLE
Change license from removed AGPL-3 to GPL-3 in Nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -14,6 +14,6 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "This bot allows you to prevent the usage of those cursed premium stickers in your telegram chat";
     homepage = "https://github.com/DomesticMoth/bps";
-    license = licenses.agpl3;
+    license = licenses.gpl3;
   };
 }


### PR DESCRIPTION
```
        at /nix/store/pr9f620z2sndzpglpnp07mw843z3s3ck-source/package.nix:17:15:

           16|     homepage = "https://github.com/DomesticMoth/bps";
           17|     license = licenses.agpl3;
             |               ^
           18|   };
       Did you mean one of gpl3, lgpl3, afl3, gpl2 or lgpl2?
```